### PR TITLE
Fix collisionbox when turning off invisible

### DIFF
--- a/description.txt
+++ b/description.txt
@@ -1,0 +1,1 @@
+Allows admins/moderators to make players/themselves invisible.

--- a/init.lua
+++ b/init.lua
@@ -86,3 +86,8 @@ minetest.register_chatcommand("vanish", {
 
 	end
 })
+
+-- Log
+if minetest.settings:get_bool("log_mods") then
+minetest.log("action", "[MOD] Invisibility loaded")
+end		

--- a/init.lua
+++ b/init.lua
@@ -41,7 +41,7 @@ invisible = function(player, toggle)
 		-- show player and tag
 		prop = {
 			visual_size = {x = 1, y = 1},
-			collisionbox = {-0.35, -1, -0.35, 0.35, 1, 0.35}
+			collisionbox = {-0.3, 0.0, -0.3, 0.3, 1.7, 0.3}
 		}
 
 		player:set_nametag_attributes({

--- a/mod.conf
+++ b/mod.conf
@@ -1,0 +1,3 @@
+name = invisibility
+depends = default, vessels, flowers
+description = Allows admins/moderators to make players/themselves invisible.

--- a/mod.conf
+++ b/mod.conf
@@ -1,3 +1,3 @@
 name = invisibility
-depends = default, vessels, flowers
+depends = default, vessels
 description = Allows admins/moderators to make players/themselves invisible.


### PR DESCRIPTION
After playing for a while with MT 5.0.0 and with this mod enabled, I noticed my collisionbox was made bigger after turning back to normal.
This commit fixes this error (Only for 5.0.0+. Works both with "dev" and "master" branches).